### PR TITLE
make it work with Python 3

### DIFF
--- a/bin/conway.py
+++ b/bin/conway.py
@@ -9,7 +9,8 @@ A board is represented like this::
 ...where ``state`` is an int from 0..2 representing a color.
 
 """
-from contextlib import nested
+from __future__ import print_function
+#from contextlib import nested
 from itertools import chain
 from random import randint
 from sys import stdout
@@ -20,8 +21,9 @@ from blessings import Terminal
 
 def main():
     """Play Conway's Game of Life on the terminal."""
-    def die((x, y)):
+    def die(x_y):
         """Pretend any out-of-bounds cell is dead."""
+        x, y = x_y
         if 0 <= x < width and 0 <= y < height:
             return x, y
 
@@ -35,7 +37,7 @@ def main():
     detector = BoredomDetector()
     cells = cell_strings(term)
 
-    with nested(term.fullscreen(), term.hidden_cursor()):
+    with term.fullscreen(), term.hidden_cursor():
         try:
             while True:
                 frame_end = time() + 0.05
@@ -86,20 +88,20 @@ def cell_strings(term):
 def random_board(max_x, max_y, load_factor):
     """Return a random board with given max x and y coords."""
     return dict(((randint(0, max_x), randint(0, max_y)), 0) for _ in
-                xrange(int(max_x * max_y / load_factor)))
+                range(int(max_x * max_y / load_factor)))
 
 
 def clear(board, term, height):
     """Clear the droppings of the given board."""
-    for y in xrange(height):
-        print term.move(y, 0) + term.clear_eol,
+    for y in range(height):
+        print(term.move(y, 0) + term.clear_eol, end='')
 
 
 def draw(board, term, cells):
     """Draw a board to the terminal."""
-    for (x, y), state in board.iteritems():
+    for (x, y), state in board.items():
         with term.location(x, y):
-            print cells[state],
+            print(cells[state], end='')
 
 
 def next_board(board, wrap):
@@ -115,7 +117,7 @@ def next_board(board, wrap):
     new_board = {}
 
     # We need consider only the points that are alive and their neighbors:
-    points_to_recalc = set(board.iterkeys()) | set(chain(*map(neighbors, board)))
+    points_to_recalc = set(board.keys()) | set(chain(*map(neighbors, board)))
 
     for point in points_to_recalc:
         count = sum((neigh in board) for neigh in
@@ -135,8 +137,9 @@ def next_board(board, wrap):
     return new_board
 
 
-def neighbors((x, y)):
+def neighbors(x_y):
     """Return the (possibly out of bounds) neighbors of a point."""
+    x, y  = x_y
     yield x + 1, y
     yield x - 1, y
     yield x, y + 1

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Artistic Software',
         'Topic :: Games/Entertainment :: Simulation',
         'Topic :: Scientific/Engineering :: Artificial Life',


### PR DESCRIPTION
Not a perfect modification for working on both Python 2 and 3, but it does run on Python 2.7 and 3.3.

I don't have <2.7 to test, I pretty sure it's break since I remove the `nested`, it probably is best to literally nest, but I don't want to add another indentation level. Also `xrange` and `iter*`, I just simply edited with Python 3's.